### PR TITLE
Fix phone number detection for new YESSS UI layout

### DIFF
--- a/KontomanagerClient/KontomanagerClient.cs
+++ b/KontomanagerClient/KontomanagerClient.cs
@@ -118,20 +118,74 @@ namespace KontomanagerClient
 
         private string ExtractSelectedPhoneNumberFromSettingsPage(string settingsPageHtml)
         {
+            if (string.IsNullOrWhiteSpace(settingsPageHtml))
+                return null;
+        
             var doc = new HtmlDocument();
             doc.LoadHtml(settingsPageHtml);
-
-            foreach (var row in doc.DocumentNode.SelectNodes("//li[@class='list-group-item']"))
+        
+            // 1) New YESSS layout:
+            //    The phone number is in the header dropdown:
+            //    <button id="user-dropdown"><span>0681/20323724</span></button>
+            var dropdownSpan = doc.DocumentNode.SelectSingleNode("//button[@id='user-dropdown']//span");
+            if (dropdownSpan != null)
             {
-                if (row.HasClass("list-group-header")) continue;
-                var d = row.SelectSingleNode("./div");
-                var sides = d.SelectNodes("./div");
-                if (sides.Count < 2 ||
-                    !sides[0].InnerText.StartsWith("Rufnummer")) continue;
-                return sides.Last().InnerText;
+                var text = HtmlEntity.DeEntitize(dropdownSpan.InnerText)?.Trim();
+                var number = ExtractPhoneNumber(text);
+                if (!string.IsNullOrWhiteSpace(number))
+                    return number;
             }
-
+        
+            // 2) Fallback: Read text directly from the button
+            var dropdownButton = doc.DocumentNode.SelectSingleNode("//button[@id='user-dropdown']");
+            if (dropdownButton != null)
+            {
+                var text = HtmlEntity.DeEntitize(dropdownButton.InnerText)?.Trim();
+                var number = ExtractPhoneNumber(text);
+                if (!string.IsNullOrWhiteSpace(number))
+                    return number;
+            }
+        
+            // 3) Old approach via list-group-item / "phone number"
+            var infoItems = doc.DocumentNode.SelectNodes("//li[contains(@class,'list-group-item')]");
+            if (infoItems != null)
+            {
+                foreach (var item in infoItems)
+                {
+                    var text = HtmlEntity.DeEntitize(item.InnerText)?.Trim();
+                    if (string.IsNullOrWhiteSpace(text))
+                        continue;
+        
+                    if (text.Contains("Rufnummer", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var number = ExtractPhoneNumber(text);
+                        if (!string.IsNullOrWhiteSpace(number))
+                            return number;
+                    }
+                }
+            }
+        
+            // 4) Last resort: search the entire page for an Austrian number.
+            var pageText = HtmlEntity.DeEntitize(doc.DocumentNode.InnerText ?? string.Empty);
+            var fallbackNumber = ExtractPhoneNumber(pageText);
+            if (!string.IsNullOrWhiteSpace(fallbackNumber))
+                return fallbackNumber;
+        
             return null;
+        }
+
+        private string ExtractPhoneNumber(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return null;
+        
+            // Examples:
+            // 0681/20323724    068120323724    +4368120323724    4368120323724
+            var match = Regex.Match(text, @"(\+?43|0)[0-9/\s\-]{6,}");
+            if (!match.Success)
+                return null;
+        
+            return match.Value.Trim();
         }
         
         private PhoneNumber ExtractPhoneNumberFromDropdown(HtmlNode liNode)


### PR DESCRIPTION
## Problem

The YESSS Kontomanager UI has changed and the current implementation may fail to detect the selected phone number.

Previously, the library expected the phone number to be present:

- in the settings page
- within `list-group-item` entries
- labeled with "Rufnummer"

In the current UI, the active phone number is displayed in the header dropdown:

```html
<button id="user-dropdown">
    <span>0681/xxxxxxxxxx</span>
</button>
```

Since this structure was not considered by the existing parser, the method  
`GetSelectedPhoneNumber()` could throw:

```
Exception: Phone number could not be found
```

This affects all YESSS accounts where only a single number is present and no number switching is configured.

---

## Solution

The phone number extraction logic was extended to support the new UI layout.

The method `ExtractSelectedPhoneNumberFromSettingsPage()` now:

1. First checks the header dropdown (`#user-dropdown span`)
2. Falls back to the previous list-group based detection
3. Falls back to a generic regex search on the full page

This ensures compatibility with:

- new YESSS UI
- older UI layouts
- accounts with single or multiple phone numbers

---

## Result

The correct phone number is now detected reliably across different UI versions.

This prevents runtime failures when calling:

```csharp
GetSelectedPhoneNumber()
```

and restores functionality for affected YESSS accounts.

---

## Tested with

- YESSS prepaid account
- Expert mode UI
- Single phone number (no group function)
- New UI layout (header dropdown based number display)

---

## Notes

This change is backward compatible and does not affect other providers.
